### PR TITLE
warnings were removed

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -24,7 +24,8 @@ class Categories:
         categories = self._fill_aliases(categories)
         return categories
 
-    def _fill_aliases(self, categories: List[Dict]) -> List[Category]:
+    @staticmethod
+    def _fill_aliases(categories: List[Dict]) -> List[Category]:
         """Заполняет по каждой категории aliases, то есть возможные
         названия этой категории, которые можем писать в тексте сообщения.
         Например, категория «кафе» может быть написана как cafe,
@@ -43,7 +44,7 @@ class Categories:
             ))
         return categories_result
 
-    def get_all_categories(self) -> List[Dict]:
+    def get_all_categories(self) -> List[Category]:
         """Возвращает справочник категорий."""
         return self._categories
 

--- a/db.py
+++ b/db.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 import sqlite3
 
@@ -9,9 +9,9 @@ cursor = conn.cursor()
 
 
 def insert(table: str, column_values: Dict):
-    columns = ', '.join( column_values.keys() )
+    columns = ', '.join(column_values.keys())
     values = [tuple(column_values.values())]
-    placeholders = ", ".join( "?" * len(column_values.keys()) )
+    placeholders = ", ".join("?" * len(column_values.keys()))
     cursor.executemany(
         f"INSERT INTO {table} "
         f"({columns}) "
@@ -20,7 +20,7 @@ def insert(table: str, column_values: Dict):
     conn.commit()
 
 
-def fetchall(table: str, columns: List[str]) -> List[Tuple]:
+def fetchall(table: str, columns: List[str]) -> List[Dict]:
     columns_joined = ", ".join(columns)
     cursor.execute(f"SELECT {columns_joined} FROM {table}")
     rows = cursor.fetchall()

--- a/expenses.py
+++ b/expenses.py
@@ -29,7 +29,7 @@ def add_expense(raw_message: str) -> Expense:
     parsed_message = _parse_message(raw_message)
     category = Categories().get_category(
         parsed_message.category_text)
-    inserted_row_id = db.insert("expense", {
+    db.insert("expense", {
         "amount": parsed_message.amount,
         "created": _get_now_formatted(),
         "category_codename": category.codename,
@@ -111,7 +111,7 @@ def _parse_message(raw_message: str) -> Message:
             "Не могу понять сообщение. Напишите сообщение в формате, "
             "например:\n1500 метро")
 
-    amount = regexp_result.group(1).replace(" ", "")
+    amount = int(regexp_result.group(1).replace(" ", ""))
     category_text = regexp_result.group(2).strip().lower()
     return Message(amount=amount, category_text=category_text)
 

--- a/server.py
+++ b/server.py
@@ -51,8 +51,8 @@ async def del_expense(message: types.Message):
 async def categories_list(message: types.Message):
     """Отправляет список категорий расходов"""
     categories = Categories().get_all_categories()
-    answer_message = "Категории трат:\n\n* " +\
-            ("\n* ".join([c.name+' ('+", ".join(c.aliases)+')' for c in categories]))
+    answer_message = "Категории трат:\n\n* " + \
+                     ("\n* ".join([c.name + ' (' + ", ".join(c.aliases) + ')' for c in categories]))
     await message.answer(answer_message)
 
 
@@ -82,8 +82,8 @@ async def list_expenses(message: types.Message):
         f"{expense.amount} руб. на {expense.category_name} — нажми "
         f"/del{expense.id} для удаления"
         for expense in last_expenses]
-    answer_message = "Последние сохранённые траты:\n\n* " + "\n\n* "\
-            .join(last_expenses_rows)
+    answer_message = "Последние сохранённые траты:\n\n* " + "\n\n* " \
+        .join(last_expenses_rows)
     await message.answer(answer_message)
 
 


### PR DESCRIPTION
Убрал warning-и PyCharm

В методе _parse_message переменная amount была типа str, а должна была быть int. При передаче ее через NamedTuple Message в NamedTuple Expense, а затем в функцию insert она все еще оставалась типа str. Однако при методе executemany сложение в базе данных происходило правильно. Как так, если формат был неверен? Библиотека sqllite3 автоматически перевела в нужный тип?